### PR TITLE
Enable GHC 9.6.5

### DIFF
--- a/borsh.cabal
+++ b/borsh.cabal
@@ -29,7 +29,8 @@ tested-with:
   , GHC == 8.10.7
   , GHC == 9.0.2
   , GHC == 9.2.7
-  , GHC == 9.4.4
+  , GHC == 9.4.8
+  , GHC == 9.6.5
 
 source-repository head
   type:     git
@@ -43,7 +44,7 @@ common lang
     ghc-options:
       -Wunused-packages
   build-depends:
-      base >= 4.12 && < 4.18
+      base >= 4.12 && < 4.19
   default-language:
       Haskell2010
   default-extensions:


### PR DESCRIPTION
Small change to enable the use of this library with GHC 9.6.5.